### PR TITLE
Make piston-internal dependencies more explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ homepage = "https://github.com/pistondevelopers/glutin_window"
 name = "glutin_window"
 path = "src/lib.rs"
 
-[dependencies.piston]
-git = "https://github.com/PistonDevelopers/piston"
+[dependencies.pistoncore-input]
+git = "https://github.com/PistonDevelopers/input"
+#version = "0.0.9"
+
+[dependencies.pistoncore-window]
+git = "https://github.com/PistonDevelopers/window"
 #version = "0.1.0"
 
 [dependencies.shader_version]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,18 @@
 
 extern crate glutin;
 extern crate gl;
-extern crate piston;
+extern crate input;
+extern crate window;
 extern crate shader_version;
 
 // External crates.
-use piston::input::{
+use input::{
     keyboard,
     MouseButton,
     Button,
     Input,
 };
-use piston::window::{
+use window::{
     OpenGLWindow,
     Window,
     AdvancedWindow,
@@ -71,7 +72,7 @@ impl GlutinWindow {
 
     fn poll_event(&mut self) -> Option<Input> {
         use glutin::Event as E;
-        use piston::input::{ Key, Input, Motion };
+        use input::{ Key, Input, Motion };
 
         if let Some((x, y)) = self.last_mouse_pos {
             self.last_mouse_pos = None;
@@ -182,7 +183,7 @@ impl OpenGLWindow for GlutinWindow {
 
 /// Maps Glutin's key to Piston's key.
 pub fn map_key(keycode: glutin::VirtualKeyCode) -> keyboard::Key {
-    use piston::input::keyboard::Key;
+    use input::keyboard::Key;
     use glutin::VirtualKeyCode as K;
 
     match keycode {


### PR DESCRIPTION
The Piston crate also contains pistoncore-event, which is not required here. Therefore we only have to depend on the necessary input and window crates.
