### PR TITLE
Add MouseScroll event for LineDelta with correct formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ impl GlutinWindow {
             }
             Some(E::MouseWheel(MouseScrollDelta::PixelDelta(x, y))) =>
                 Some(Input::Move(Motion::MouseScroll(x as f64, y as f64))),
+            Some(E::MouseWheel(MouseScrollDelta::LineDelta(x, y))) =>
+                Some(Input::Move(Motion::MouseScroll(x as f64, y as f64))),
             Some(E::MouseInput(glutin::ElementState::Pressed, button)) =>
                 Some(Input::Press(Button::Mouse(map_mouse(button)))),
             Some(E::MouseInput(glutin::ElementState::Released, button)) =>


### PR DESCRIPTION
This fixes an issue on windows where the scoll event is not fired
