### PR TITLE
Generate missing Resize events by tracking window and resize dimensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gl = "0.6.0"
-glutin = "0.6.1"
+glutin = "0.7.0"
 pistoncore-input = "0.14.0"
 pistoncore-window = "0.23.0"
 shader_version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-glutin_window"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["glutin", "window", "piston"]
 description = "A Piston window back-end using the Glutin library"
@@ -11,7 +11,6 @@ repository = "https://github.com/pistondevelopers/glutin_window.git"
 homepage = "https://github.com/pistondevelopers/glutin_window"
 
 [lib]
-
 name = "glutin_window"
 path = "src/lib.rs"
 


### PR DESCRIPTION
Track the dimensions of the last resize event and compare them to the
window dimensions each time an event is polled in order to determine
whether or not we need to generate new Resize events. We do this in
order to solve the problem where glutin (winit) is unable to produce
Resize events for Mac OS and possibly other operating systems.

The reason why we track the last emitted resize instead of the window
dimensions is so that we avoid generating duplicate events on systems
that already successfully generate Resize events.

Also cleans up the window's `size` and `draw_size` events by using the
glutin::Window methods specified for this purpose.

@bvssvni do you think this is acceptable to add? It shouldn't affect the
behaviour for folks who already get resize events successfully, however
it should make life a bit easier for folks on Mac OS who weren't previously
able to receive Resize events and currently have to resort to doing this
sort of window size tracking themselves.

Closes #88.