### PR TITLE
Using latest version of glutin as dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gl = "0.6.0"
-glutin = "0.7.0"
+glutin = "*"
 pistoncore-input = "0.15.0"
 pistoncore-window = "0.24.0"
 shader_version = "0.2.1"


### PR DESCRIPTION
This should fix [this issue](https://github.com/PistonDevelopers/Piston-Tutorials/issues/144) once the guys at [https://github.com/tomaka/glutin](https://github.com/tomaka/glutin) push a new version to crates.io, fixing [this issue](https://github.com/tomaka/glutin/issues/834).

As an alternative the version can be hardcoded once they release the next version.