### PR TITLE
Improve the error message from GlutinWindow::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl GlutinWindow {
                 Ok(window) => window,
                 Err(_) => {
                     try!(builder_from_settings(&settings.clone().samples(0)).build()
-                        .map_err(|e| String::from(e.description()))
+                        .map_err(|e| format!("{}", e))
                     )
                 }
             };


### PR DESCRIPTION
`Display::fmt` gives more detail than `Error::description`.