### PR TITLE
Update to glutin 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gl = "0.6.0"
-glutin = "0.8.0"
+glutin = "0.9.0"
 pistoncore-input = "0.18.0"
 pistoncore-window = "0.27.0"
 shader_version = "0.2.1"


### PR DESCRIPTION
glutin 0.9.0 was recently released, which includes an API change that splits the concept of "window" and "GL context" into two separate concepts (tomaka/glutin#901) with two separate builders. Other relevant changes include:

* Introducing `glutin::GlWindow` (which is what we want here),
* Plumbing down `device_id` on various input events (which are all summarily discarded),
* Changing the window event enums to structs instead of tuples (which is what probably prompted that change),
* Switching cursor positions to `f64` (which are summarily reduced to `i32` in most cases), and
* Introducing an event loop proxy which can interrupt the event loop, rather than requiring multiple references to the event loop itself.

glutin 0.9.0 also bumps winit to 0.7, which has some significant internal changes on Windows (tomaka/winit#209) and MacOS X (tomaka/winit#210).