### PR TITLE
Detect and correct `get_inner_size` bug in Glutin api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-glutin_window"
-version = "0.45.1"
+version = "0.45.2"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["glutin", "window", "piston"]
 description = "A Piston window back-end using the Glutin library"


### PR DESCRIPTION
This fixes a bug that is present on OSX.

- Bumped to 0.45.2