### PR TITLE
Use resizable setting when building window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gl = "0.10.0"
-glutin = "0.14.0"
+glutin = "0.16.0"
 pistoncore-input = "0.21.0"
 pistoncore-window = "0.32.0"
 shader_version = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@ fn window_builder_from_settings(settings: &WindowSettings) -> glutin::WindowBuil
         .with_dimensions(size.width, size.height)
         .with_decorations(settings.get_decorated())
         .with_multitouch()
-        .with_title(settings.get_title());
+        .with_title(settings.get_title())
+        .with_resizable(settings.get_resizable());
     if settings.get_fullscreen() {
         let events_loop = glutin::EventsLoop::new();
         builder = builder.with_fullscreen(Some(events_loop.get_primary_monitor()));
@@ -396,7 +397,7 @@ impl GlutinWindow {
                 button: Button::Mouse(map_mouse(button)),
                 scancode: None,
             })),
-            Some(E::WindowEvent { event: WE::Closed, .. }) => {
+            Some(E::WindowEvent { event: WE::CloseRequested, .. }) => {
                 self.should_close = true;
                 Some(Input::Close(CloseArgs))
             }


### PR DESCRIPTION
This uses the `resizable` setting from the `window::WindowSettings` to actually be able to enable/disable resizing. Requires glutin to be bumped to `0.16.0`, so it might be better for this to land after #141 is finished, so this can be adjusted with a quick swoop.