### PR TITLE
Fix dpi scaling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,6 @@ pub struct GlutinWindow {
     events_loop: glutin::EventsLoop,
     // Stores list of events ready for processing.
     events: VecDeque<glutin::Event>,
-    // Corrects the units of `get_inner_size` bug in Glutin.
-    correct_inner_size: f64,
 }
 
 fn window_builder_from_settings(settings: &WindowSettings) -> glutin::WindowBuilder {
@@ -138,14 +136,6 @@ impl GlutinWindow {
         // Load the OpenGL function pointers.
         gl::load_with(|s| window.get_proc_address(s) as *const _);
 
-        // Detect bug in Glutin api for `get_inner_size`.
-        let size = settings.get_size();
-        let size = (size.width, size.height).into();
-        let hidpi = window.get_hidpi_factor();
-        let correct_inner_size = if let Some(inner_size) = window.get_inner_size() {
-            if hidpi != 1.0 && inner_size == size {hidpi} else {1.0}
-        } else {1.0};
-
         Ok(GlutinWindow {
             window: window,
             title: title,
@@ -157,7 +147,6 @@ impl GlutinWindow {
             mouse_relative: None,
             events_loop: events_loop,
             events: VecDeque::new(),
-            correct_inner_size,
         })
     }
 
@@ -435,13 +424,14 @@ impl GlutinWindow {
 impl Window for GlutinWindow {
     fn size(&self) -> Size {
         let size = self.window.get_inner_size().unwrap_or((0.0, 0.0).into());
-        let hidpi = self.window.get_hidpi_factor() / self.correct_inner_size;
-        ((size.width / hidpi) as u32, (size.height / hidpi) as u32).into()
+        (size.width as u32, size.height as u32).into()
     }
     fn draw_size(&self) -> Size {
-        let size = self.window.get_inner_size().unwrap_or((0.0, 0.0).into());
-        let correct = self.correct_inner_size;
-        ((size.width * correct) as u32, (size.height * correct) as u32).into()
+        let size = self.window
+            .get_inner_size()
+            .unwrap_or((0.0, 0.0).into())
+            .to_physical(self.window.get_hidpi_factor());
+        (size.width as u32, size.height as u32).into()
     }
     fn should_close(&self) -> bool { self.should_close }
     fn set_should_close(&mut self, value: bool) { self.should_close = value; }


### PR DESCRIPTION
Fixes #145.

I've tested this on Linux (X and i3) and Windows 10, but I don't have a Mac to test on.

This `correct_inner_size` claims to work around a bug in glutin's `get_inner_size`, but I don't think that bug exists anymore...? So I removed it. The code seemed hacky, and I've replaced it with something that seems more in line with what the glutin docs for [`get_inner_size`](https://docs.rs/glutin/0.18.0/glutin/struct.Window.html#method.get_inner_size) say.