### PR TITLE
Fix AdvancedWindow::set_size dpi scaling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,10 +476,9 @@ impl AdvancedWindow for GlutinWindow {
     }
     fn set_size<S: Into<Size>>(&mut self, size: S) {
         let size: Size = size.into();
-        let hidpi = self.window.get_hidpi_factor();
         self.window.set_inner_size((
-            size.width as f64 * hidpi,
-            size.height as f64 * hidpi
+            size.width as f64,
+            size.height as f64,
         ).into());
     }
 }


### PR DESCRIPTION
More like remove the dpi scaling since glutin handles it. With this, the only mention of dpi left in this library is in `Window::draw_size`.