### PR TITLE
Add support for `Input::FileDrag`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use input::{
     MouseButton,
     Button,
     Input,
+    FileDrag
 };
 use window::{
     BuildFromWindowSettings,
@@ -373,6 +374,15 @@ impl GlutinWindow {
                 button: Button::Mouse(map_mouse(button)),
                 scancode: None,
             })),
+            Some(E::WindowEvent {
+                event: WE::HoveredFile(path), ..
+            }) => Some(Input::FileDrag(FileDrag::Hover(path))),
+            Some(E::WindowEvent {
+                event: WE::DroppedFile(path), ..
+            }) => Some(Input::FileDrag(FileDrag::Drop(path))),
+            Some(E::WindowEvent {
+                event: WE::HoveredFileCancelled, ..
+            }) => Some(Input::FileDrag(FileDrag::Cancel)),
             Some(E::WindowEvent { event: WE::CloseRequested, .. }) => {
                 self.should_close = true;
                 Some(Input::Close(CloseArgs))


### PR DESCRIPTION
This adds support for `Input::FileDrag` that I [recently added to piston core](https://github.com/PistonDevelopers/piston/pull/1269).