### PR TITLE
Fix UB in `make_current`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,8 @@ impl OpenGLWindow for GlutinWindow {
     fn make_current(&mut self) {
         unsafe {
             let ctx = std::ptr::read(&self.ctx);
-            match ctx.make_current() {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| ctx.make_current())).unwrap_or_else(|_| std::process::abort());
+            match result {
                 Ok(ctx) => {
                     std::ptr::write(&mut self.ctx, ctx);
                 }


### PR DESCRIPTION
#188 doesn't actually fix the core issue, it just papers over it; UB still occurs while zero initializing a type that disallows zero initialization. I believe this version fixes the UB. It performs no zero initialization, instead using [`std::ptr::read`](https://doc.rust-lang.org/std/ptr/fn.read.html) to get a copy, perform the function that consumes it, then write back the result if it succeeded, or the `ctx` from the error if it failed. 

Edit:
I also try to catch panics in `make_current` and abort since there's not much I can do there. I feel like `ctx` really should just be an `Option`.