### PR TITLE
Automatic context resize in MacOS platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,17 @@ impl GlutinWindow {
         None
     }
 
+    /// Some playforms (MacOS and Wayland) require the context to resize on
+    /// window resize. Check: https://github.com/PistonDevelopers/graphics/issues/1129
+    #[cfg(target_os = "macos")]
+    fn requires_context_resize() -> bool {
+        true
+    }
+    #[cfg(not(target_os = "macos"))]
+    fn requires_context_resize() -> bool {
+        false
+    }
+
     /// Convert an incoming Glutin event to Piston input.
     /// Update cursor state if necessary.
     ///
@@ -299,6 +310,12 @@ impl GlutinWindow {
                 event: WE::Resized(size), ..
             }) => {
                 let draw_size = self.draw_size();
+                if Self::requires_context_resize() {
+                    self.ctx.resize(glutin::dpi::PhysicalSize {
+                        width: draw_size.width,
+                        height: draw_size.height
+                    });
+                }
                 Some(Input::Resize(ResizeArgs {
                     window_size: [size.width, size.height],
                     draw_size: draw_size.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,17 +276,6 @@ impl GlutinWindow {
         None
     }
 
-    /// Some playforms (MacOS and Wayland) require the context to resize on
-    /// window resize. Check: https://github.com/PistonDevelopers/graphics/issues/1129
-    #[cfg(target_os = "macos")]
-    fn requires_context_resize() -> bool {
-        true
-    }
-    #[cfg(not(target_os = "macos"))]
-    fn requires_context_resize() -> bool {
-        false
-    }
-
     /// Convert an incoming Glutin event to Piston input.
     /// Update cursor state if necessary.
     ///
@@ -310,12 +299,15 @@ impl GlutinWindow {
                 event: WE::Resized(size), ..
             }) => {
                 let draw_size = self.draw_size();
-                if Self::requires_context_resize() {
-                    self.ctx.resize(glutin::dpi::PhysicalSize {
-                        width: draw_size.width,
-                        height: draw_size.height
-                    });
-                }
+                
+                // Some platforms (MacOS and Wayland) require the context to resize on window
+                // resize. Check: https://github.com/PistonDevelopers/graphics/issues/1129
+                #[cfg(target_os = "macos")]
+                self.ctx.resize(glutin::dpi::PhysicalSize {
+                    width: draw_size.width,
+                    height: draw_size.height
+                });
+                
                 Some(Input::Resize(ResizeArgs {
                     window_size: [size.width, size.height],
                     draw_size: draw_size.into(),


### PR DESCRIPTION
Hey! First PR to any Piston-related repo.
I found this issue: https://github.com/PistonDevelopers/graphics/issues/1129
As the other issue mentions, the problem is that in some platforms (MacOS and Wayland) the glutin context needs to be resized when the window resizes. Check the docs: https://docs.rs/glutin/0.20.1/glutin/struct.WindowedContext.html#method.resize
I've fixed this problem on MacOS, where I can test the fix. I presume the problem still persists in Wayland.
I'm also pretty new to rust, so happy to change anything to make it idiomatic!