### PR TITLE
upgrade glutin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gl = "0.13.0"
-glutin = "0.25.0"
+glutin = "0.26.0"
 pistoncore-input = "1.0.0"
 pistoncore-window = "0.47.0"
 shader_version = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use window::{
     UnsupportedGraphicsApiError,
 };
 use glutin::GlRequest;
-use glutin::platform::desktop::EventLoopExtDesktop;
+use glutin::platform::run_return::EventLoopExtRunReturn;
 use std::time::Duration;
 use std::thread;
 


### PR DESCRIPTION
The examples fail on macOS Big Sur (version 11.0.1) with 

`expected 'bool', found 'i8'`

After an upgrade of glutin to version 0.26.0, and adopting one line of source code, it is also working on Big Sur.

This PR will integrate those small changes into the master.

But I'm not sure if I also have to update the version of this library.