### PR TITLE
enable resize fix on all platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,6 @@ impl GlutinWindow {
                 
                 // Some platforms (MacOS and Wayland) require the context to resize on window
                 // resize. Check: https://github.com/PistonDevelopers/graphics/issues/1129
-                #[cfg(target_os = "macos")]
                 self.ctx.resize(draw_size);
                 
                 Some(Input::Resize(ResizeArgs {


### PR DESCRIPTION
![19:16:19](https://user-images.githubusercontent.com/39013340/160461547-1cf794f5-4b42-4484-91cb-93527bc4201e.png)

*should* fix this bug on Wayland, not sure how to test for wayland like it was done for macos so now its just enabled for every platform.

No idea how it will affect windows or X.